### PR TITLE
Add a prefix to the invoice number(entry id)

### DIFF
--- a/content/content.logs.php
+++ b/content/content.logs.php
@@ -82,9 +82,16 @@
 					$col = array();
 					# Spit out $log_name vars
 					extract($log, EXTR_PREFIX_ALL, 'log');
+					$prefix = $this->_driver->_get_invoice_prefix();
+					$log_invoice_to_search_on = $log_invoice;
+					
+					# If prefix exists, lets remove it to link to an entry.
+					if (substr($log_invoice, 0, strlen($prefix)) == $prefix) {
+						$log_invoice_to_search_on = substr($log_invoice, strlen($prefix));
+					}
 					
 					# Get the entry/section data
-					$entries = $entryManager->fetch($log_invoice, NULL, NULL, NULL, NULL, NULL, FALSE, TRUE);
+					$entries = $entryManager->fetch($log_invoice_to_search_on, NULL, NULL, NULL, NULL, NULL, FALSE, TRUE);
 					$entry = $entries[0];
 					if (isset($entry))
 					{

--- a/events/event.paypal_payments_ipn.php
+++ b/events/event.paypal_payments_ipn.php
@@ -213,7 +213,13 @@
 				}
 				
 				# Reconcile with original entry
+				$prefix = $this->_driver->_get_invoice_prefix();
 				$entry_id = $log['invoice'];
+
+				# Remove Prefix if it exists
+				if (substr($entry_id, 0, strlen($prefix)) == $prefix) {
+					$entry_id = substr($entry_id, strlen($prefix));
+				}
 				
 				$entryManager = new EntryManager(Symphony::Engine());
 				$fieldManager = new FieldManager(Symphony::Engine());

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -12,8 +12,8 @@
 		public function about()
 		{
 			return array('name' => 'PayPal Payments',
-						 'version' => '1.0.4',
-						 'release-date' => '2011-05-01',
+						 'version' => '1.2',
+						 'release-date' => '2013-06-29',
 						 'author' => array('name' => 'Max Wheeler',
 										   'website' => 'http://makenosound.com/',
 										   'email' => 'max@makenosound.com'),
@@ -131,6 +131,12 @@
 			$group->setAttribute('class', 'settings');
 			$group->appendChild(new XMLElement('legend', 'PayPal Payments'));
 
+			# Add Invoice Prefix field
+			$label = Widget::Label('Invoice Prefix');
+			$label->appendChild(Widget::Input('settings[paypal-payments][prefix]', General::Sanitize($this->_get_invoice_prefix())));
+			$group->appendChild($label);
+			$group->appendChild(new XMLElement('p', 'Set a prefix of the Invoice(Optional).', array('class' => 'help')));
+
 			# Add Merchant Email field
 			$label = Widget::Label('Merchant Email/Account ID');
 			$label->appendChild(Widget::Input('settings[paypal-payments][business]', General::Sanitize($this->_get_paypal_business())));
@@ -216,6 +222,12 @@
 		{
 			$country = Symphony::Configuration()->get('country', 'paypal-payments');
 			return (isset($country)) ? $country : 'United States';
+		}
+
+		public function _get_invoice_prefix()
+		{
+			$prefix = Symphony::Configuration()->get('prefix', 'paypal-payments');
+			return (isset($prefix)) ? $prefix: '';
 		}
 
 		public function _build_paypay_url($default = false)
@@ -380,7 +392,7 @@
 
 			# Set the default dataset
 			$data = array(
-				'invoice' =>		$context['entry']->get('id'),
+				'invoice' =>		$this->_get_invoice_prefix().$context['entry']->get('id'),
 				'business' =>		$this->_get_paypal_business()
 			);
 

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -16,5 +16,6 @@
 	<releases>
 		<release version="1.0.4" date="2011-05-01" min="2.2" max="2.2.x" />
 		<release version="1.1" date="2012-07-12" min="2.3" max="2.3.x" />
+		<release version="1.2" date="2013-06-29" min="2.3" max="2.3.x" />
 	</releases>
 </extension>


### PR DESCRIPTION
You can now add a prefix to the invoice number.  Good if you have
multiple sites reporting to the same paypal account.
